### PR TITLE
Add '*' and '+' aliases for Point#multiply_by_scalar and Point#add_to_point

### DIFF
--- a/lib/ecdsa/point.rb
+++ b/lib/ecdsa/point.rb
@@ -83,6 +83,9 @@ module ECDSA
       raise "Failed to add #{inspect} to #{other.inspect}: No addition rules matched."
     end
 
+    # (see #add_to_point)
+    alias_method :+, :add_to_point
+
     # Returns the additive inverse of the point.
     #
     # @return (Point)
@@ -122,6 +125,9 @@ module ECDSA
       end
       result
     end
+
+    # (see #multiply_by_scalar)
+    alias_method :*, :multiply_by_scalar
 
     # Compares this point to another.
     #

--- a/spec/point_spec.rb
+++ b/spec/point_spec.rb
@@ -21,6 +21,10 @@ describe ECDSA::Point do
     it 'complains if the argument is negative' do
       expect { group.generator.multiply_by_scalar(-3) }.to raise_error ArgumentError, 'Scalar is negative.'
     end
+
+    it 'is aliased to :*' do
+      expect(group.generator.method(:*)).to eq group.generator.method(:multiply_by_scalar)
+    end
   end
 
   describe '#coords' do
@@ -62,6 +66,10 @@ describe ECDSA::Point do
       it 'returns the double' do
         expect(group.generator.add_to_point(group.generator)).to eq group.generator.double
       end
+    end
+
+    it 'is aliased to :+' do
+      expect(group.generator.method(:+)).to eq group.generator.method(:add_to_point)
     end
   end
 


### PR DESCRIPTION
These aliases make code that depends on ECDSA::Point much more concise and elegant. For example, rather than the following code:

``` ruby
point = point.add_to_point(other_point.multiply_by_scalar(scalar))
```

you'll now be able to write:

``` ruby
point += other_point * scalar
```
